### PR TITLE
Use secure websocket if the page was loaded over HTTPS

### DIFF
--- a/html/radio.js
+++ b/html/radio.js
@@ -234,7 +234,10 @@
         spectrum.setHighHz(highHz);
         //msg=document.getElementById('msg');
         //msg.focus();
-        ws=new WebSocket('ws://'+window.location.host);
+        ws=new WebSocket(
+            (window.location.protocol == 'https:' ? 'wss://' : 'ws://') +
+            window.location.host
+        );
         ws.onmessage=on_ws_message;
         ws.onopen=on_ws_open;
         ws.onclose=on_ws_close;


### PR DESCRIPTION
In case we're reverse-proxying to ka9q-web from a secure domain, the websocket needs to be accessed using a wss:// URL rather than ws://.

Inspect window.location.protocol to find out which one to use.